### PR TITLE
feature: interfaces

### DIFF
--- a/examples/simple.php
+++ b/examples/simple.php
@@ -20,4 +20,3 @@ function format(
         array_filter($args, static fn ($arg) => $arg !== null)
     ));
 }
-

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use crate::class::Class;
 use crate::constant::Constant;
 use crate::function::Function;
+use crate::interface::Interface;
 use crate::literal::Value;
 use crate::Generator;
 use crate::Indentation;
@@ -17,6 +18,7 @@ pub struct File {
     pub functions: Vec<Function>,
     pub constants: Vec<Constant>,
     pub classes: Vec<Class>,
+    pub interfaces: Vec<Interface>,
 }
 
 impl File {
@@ -30,6 +32,7 @@ impl File {
             constants: vec![],
             functions: vec![],
             classes: vec![],
+            interfaces: vec![],
         }
     }
 
@@ -77,6 +80,12 @@ impl File {
 
     pub fn class(mut self, class: Class) -> Self {
         self.classes.push(class.into());
+
+        self
+    }
+
+    pub fn interface(mut self, interface: Interface) -> Self {
+        self.interfaces.push(interface.into());
 
         self
     }
@@ -147,6 +156,11 @@ impl Generator for File {
 
         for class in &self.classes {
             code.push_str(&class.generate(indentation, level));
+            code.push_str("\n");
+        }
+
+        for interface in &self.interfaces {
+            code.push_str(&interface.generate(indentation, level));
             code.push_str("\n");
         }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,83 @@
+use crate::{comment::Document, attribute::AttributeGroup, Generator, Indentation, method::Method};
+
+#[derive(Debug)]
+pub struct Interface {
+    pub documentation: Option<Document>,
+    pub attributes: Vec<AttributeGroup>,
+    pub name: String,
+    pub extends: Option<String>,
+    pub methods: Vec<Method>,
+}
+
+impl Interface {
+    pub fn new<T: ToString>(name: T) -> Self {
+        Self {
+            documentation: None,
+            attributes: vec![],
+            name: name.to_string(),
+            extends: None,
+            methods: vec![],
+        }
+    }
+
+    pub fn document(mut self, documentation: Document) -> Self {
+        self.documentation = Some(documentation);
+
+        self
+    }
+
+    pub fn attributes(mut self, attributes: AttributeGroup) -> Self {
+        self.attributes.push(attributes);
+
+        self
+    }
+
+    pub fn extend<T: ToString>(mut self, extends: T) -> Self {
+        self.extends = Some(extends.to_string());
+
+        self
+    }
+
+    pub fn method(mut self, method: Method) -> Self {
+        self.methods.push(method.public());
+
+        self
+    }
+}
+
+impl Generator for Interface {
+    fn generate(&self, indentation: Indentation, level: usize) -> String {
+        let mut code = String::new();
+
+        if let Some(documentation) = &self.documentation {
+            code.push_str(&documentation.generate(indentation, level));
+        }
+
+        for attribute in &self.attributes {
+            code.push_str(&attribute.generate(indentation, level));
+        }
+
+        code.push_str(&format!("interface {}", self.name));
+
+        if let Some(extends) = &self.extends {
+            code.push_str(&format!(" extends {}", extends));
+        }
+
+        code.push_str("\n{\n");
+
+        if !self.methods.is_empty() {
+            code.push_str(
+                &self
+                    .methods
+                    .iter()
+                    .map(|method| method.generate(indentation, level + 1))
+                    .collect::<Vec<String>>()
+                    .join("\n"),
+            );
+        }
+
+        code.push_str("}\n");
+
+        code
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod method;
 pub mod modifiers;
 pub mod parameter;
 pub mod property;
+pub mod interface;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Indentation {


### PR DESCRIPTION
Introduces new `Interface` and `InterfaceMethod` types.

> Wasn't sure about the `InterfaceMethod` stuff. Re-using `Method` seemed wrong since method definitions on interfaces are pretty limited (public by default, no modifiers, no body, etc).